### PR TITLE
Tile wiring: domain-first readiness inputs + thresholds

### DIFF
--- a/src/readiness.test.ts
+++ b/src/readiness.test.ts
@@ -21,24 +21,26 @@ const cases: Case[] = [
     name: "failed precedence beats fresh",
     input: {
       now: NOW,
-      lastSuccessAt: "2026-02-21T15:59:30Z", // fresh by age
-      lastAttemptAt: "2026-02-21T15:59:50Z",
-      lastAttemptOk: false,
-      config: { freshUnderSeconds: 86400, staleUnderSeconds: 259200, failureGraceSeconds: 0 },
+      domain: {
+        lastSuccessAt: "2026-02-21T15:59:30Z", // fresh by age
+        lastAttemptAt: "2026-02-21T15:59:50Z",
+        lastAttemptOk: false,
+      },
+      thresholds: { freshUnderSeconds: 86400, staleUnderSeconds: 259200, failureGraceSeconds: 0 },
     },
     expect: { status: "failed", ageSeconds: null },
   },
   {
     name: "lastAttemptOk without lastAttemptAt throws",
-    input: { now: NOW, lastSuccessAt: NOW, lastAttemptOk: true },
+    input: { now: NOW, domain: { lastSuccessAt: NOW, lastAttemptOk: true } },
     throws: /lastAttemptAt is required/,
   },
   {
     name: "boundary at freshUnderSeconds => stale",
     input: {
       now: NOW,
-      lastSuccessAt: "2026-02-20T16:00:00Z", // 86400s old
-      config: { freshUnderSeconds: 86400, staleUnderSeconds: 259200 },
+      domain: { lastSuccessAt: "2026-02-20T16:00:00Z" }, // 86400s old
+      thresholds: { freshUnderSeconds: 86400, staleUnderSeconds: 259200 },
     },
     expect: { status: "stale", ageSeconds: 86400 },
   },
@@ -46,32 +48,32 @@ const cases: Case[] = [
     name: "boundary at staleUnderSeconds => unknown",
     input: {
       now: NOW,
-      lastSuccessAt: "2026-02-18T16:00:00Z", // 259200s old
-      config: { freshUnderSeconds: 86400, staleUnderSeconds: 259200 },
+      domain: { lastSuccessAt: "2026-02-18T16:00:00Z" }, // 259200s old
+      thresholds: { freshUnderSeconds: 86400, staleUnderSeconds: 259200 },
     },
     expect: { status: "unknown", ageSeconds: 259200 },
   },
   {
     name: "invalid now throws",
-    input: { now: "not-a-date", lastSuccessAt: NOW },
+    input: { now: "not-a-date", domain: { lastSuccessAt: NOW } },
     throws: /Invalid now timestamp/,
   },
   {
     name: "invalid lastSuccessAt throws",
-    input: { now: NOW, lastSuccessAt: "not-a-date" },
+    input: { now: NOW, domain: { lastSuccessAt: "not-a-date" } },
     throws: /Invalid lastSuccessAt timestamp/,
   },
   {
     name: "invalid lastAttemptAt throws",
-    input: { now: NOW, lastSuccessAt: NOW, lastAttemptAt: "not-a-date", lastAttemptOk: false },
+    input: { now: NOW, domain: { lastSuccessAt: NOW, lastAttemptAt: "not-a-date", lastAttemptOk: false } },
     throws: /Invalid lastAttemptAt timestamp/,
   },
   {
     name: "staleUnderSeconds < freshUnderSeconds throws",
     input: {
       now: NOW,
-      lastSuccessAt: NOW,
-      config: { freshUnderSeconds: 100, staleUnderSeconds: 99 },
+      domain: { lastSuccessAt: NOW },
+      thresholds: { freshUnderSeconds: 100, staleUnderSeconds: 99 },
     },
     throws: /staleUnderSeconds must be >= freshUnderSeconds/,
   },

--- a/src/readiness.test.ts
+++ b/src/readiness.test.ts
@@ -77,6 +77,24 @@ const cases: Case[] = [
     },
     throws: /staleUnderSeconds must be >= freshUnderSeconds/,
   },
+  {
+    name: "legacy shape: top-level timestamps + config thresholds still work",
+    input: {
+      now: NOW,
+      lastSuccessAt: "2026-02-21T15:59:00Z",
+      config: { freshUnderSeconds: 120, staleUnderSeconds: 300 },
+    },
+    expect: { status: "fresh", ageSeconds: 60 },
+  },
+  {
+    name: "legacy shape: lastAttemptOk without lastAttemptAt still throws",
+    input: {
+      now: NOW,
+      lastSuccessAt: NOW,
+      lastAttemptOk: false,
+    },
+    throws: /lastAttemptAt is required/,
+  },
 ];
 
 describe("deriveReadiness", () => {

--- a/src/readiness.ts
+++ b/src/readiness.ts
@@ -1,15 +1,25 @@
 export type ReadinessStatus = "fresh" | "stale" | "unknown" | "failed";
 
-export type ReadinessInput = {
+export type ReadinessDomain = {
   lastSuccessAt?: string; // ISO timestamp
   lastAttemptAt?: string; // ISO timestamp
   lastAttemptOk?: boolean;
+};
+
+export type ReadinessThresholds = {
+  freshUnderSeconds?: number; // default 86400
+  staleUnderSeconds?: number; // default 259200
+  failureGraceSeconds?: number; // default 0
+};
+
+export type ReadinessInput = {
+  /** Domain-first props: all “real world” timestamps live under domain. */
+  domain: ReadinessDomain;
+
   now?: string; // ISO timestamp (defaults to Date.now())
-  config?: {
-    freshUnderSeconds?: number; // default 86400
-    staleUnderSeconds?: number; // default 259200
-    failureGraceSeconds?: number; // default 0
-  };
+
+  /** Knobs live under thresholds (not config). */
+  thresholds?: ReadinessThresholds;
 };
 
 export type ReadinessDerived = {
@@ -18,9 +28,9 @@ export type ReadinessDerived = {
 };
 
 export function deriveReadiness(input: ReadinessInput): ReadinessDerived {
-  const freshUnder = input.config?.freshUnderSeconds ?? 86400;
-  const staleUnder = input.config?.staleUnderSeconds ?? 259200;
-  const failureGrace = input.config?.failureGraceSeconds ?? 0;
+  const freshUnder = input.thresholds?.freshUnderSeconds ?? 86400;
+  const staleUnder = input.thresholds?.staleUnderSeconds ?? 259200;
+  const failureGrace = input.thresholds?.failureGraceSeconds ?? 0;
 
   const nowMs = input.now ? Date.parse(input.now) : Date.now();
   if (Number.isNaN(nowMs)) throw new Error("Invalid now timestamp");
@@ -29,25 +39,27 @@ export function deriveReadiness(input: ReadinessInput): ReadinessDerived {
     throw new Error("staleUnderSeconds must be >= freshUnderSeconds");
   }
 
+  const { lastAttemptAt, lastAttemptOk, lastSuccessAt } = input.domain;
+
   // Validation: lastAttemptOk requires lastAttemptAt
-  if (typeof input.lastAttemptOk === "boolean" && !input.lastAttemptAt) {
+  if (typeof lastAttemptOk === "boolean" && !lastAttemptAt) {
     throw new Error("lastAttemptAt is required when lastAttemptOk is provided");
   }
 
-  const attemptMs = input.lastAttemptAt ? Date.parse(input.lastAttemptAt) : null;
-  if (input.lastAttemptAt && Number.isNaN(attemptMs!)) {
+  const attemptMs = lastAttemptAt ? Date.parse(lastAttemptAt) : null;
+  if (lastAttemptAt && Number.isNaN(attemptMs!)) {
     throw new Error("Invalid lastAttemptAt timestamp");
   }
 
   // Precedence: failed wins before freshness buckets
-  if (input.lastAttemptOk === false && attemptMs !== null) {
+  if (lastAttemptOk === false && attemptMs !== null) {
     const sinceAttempt = Math.max(0, Math.floor((nowMs - attemptMs) / 1000));
     if (sinceAttempt >= failureGrace) return { ageSeconds: null, status: "failed" };
   }
 
-  if (!input.lastSuccessAt) return { ageSeconds: null, status: "unknown" };
+  if (!lastSuccessAt) return { ageSeconds: null, status: "unknown" };
 
-  const successMs = Date.parse(input.lastSuccessAt);
+  const successMs = Date.parse(lastSuccessAt);
   if (Number.isNaN(successMs)) throw new Error("Invalid lastSuccessAt timestamp");
 
   const ageSeconds = Math.max(0, Math.floor((nowMs - successMs) / 1000));

--- a/src/readiness.ts
+++ b/src/readiness.ts
@@ -22,24 +22,55 @@ export type ReadinessInput = {
   thresholds?: ReadinessThresholds;
 };
 
+/**
+ * Back-compat for pre-domain/thresholds call sites.
+ *
+ * Deprecated: prefer `ReadinessInput` with `{ domain, thresholds }`.
+ */
+export type ReadinessInputLegacy = ReadinessDomain & {
+  now?: string;
+
+  /** Legacy name for tuning knobs. */
+  config?: ReadinessThresholds;
+
+  /** Allow "thresholds" in legacy form too (a lot of call sites only moved one side). */
+  thresholds?: ReadinessThresholds;
+};
+
 export type ReadinessDerived = {
   ageSeconds: number | null;
   status: ReadinessStatus;
 };
 
-export function deriveReadiness(input: ReadinessInput): ReadinessDerived {
-  const freshUnder = input.thresholds?.freshUnderSeconds ?? 86400;
-  const staleUnder = input.thresholds?.staleUnderSeconds ?? 259200;
-  const failureGrace = input.thresholds?.failureGraceSeconds ?? 0;
+function normalizeReadinessInput(input: ReadinessInput | ReadinessInputLegacy): ReadinessInput {
+  if ("domain" in input) return input;
 
-  const nowMs = input.now ? Date.parse(input.now) : Date.now();
+  return {
+    now: input.now,
+    thresholds: input.thresholds ?? input.config,
+    domain: {
+      lastSuccessAt: input.lastSuccessAt,
+      lastAttemptAt: input.lastAttemptAt,
+      lastAttemptOk: input.lastAttemptOk,
+    },
+  };
+}
+
+export function deriveReadiness(input: ReadinessInput | ReadinessInputLegacy): ReadinessDerived {
+  const normalized = normalizeReadinessInput(input);
+
+  const freshUnder = normalized.thresholds?.freshUnderSeconds ?? 86400;
+  const staleUnder = normalized.thresholds?.staleUnderSeconds ?? 259200;
+  const failureGrace = normalized.thresholds?.failureGraceSeconds ?? 0;
+
+  const nowMs = normalized.now ? Date.parse(normalized.now) : Date.now();
   if (Number.isNaN(nowMs)) throw new Error("Invalid now timestamp");
 
   if (staleUnder < freshUnder) {
     throw new Error("staleUnderSeconds must be >= freshUnderSeconds");
   }
 
-  const { lastAttemptAt, lastAttemptOk, lastSuccessAt } = input.domain;
+  const { lastAttemptAt, lastAttemptOk, lastSuccessAt } = normalized.domain;
 
   // Validation: lastAttemptOk requires lastAttemptAt
   if (typeof lastAttemptOk === "boolean" && !lastAttemptAt) {

--- a/src/readinessTile.ts
+++ b/src/readinessTile.ts
@@ -1,0 +1,41 @@
+import { deriveReadiness, type ReadinessInput, type ReadinessStatus } from "./readiness";
+
+export type ReadinessTile = {
+  kind: "readiness";
+  title: string;
+  status: ReadinessStatus;
+  subtitle: string;
+  ageSeconds: number | null;
+};
+
+function formatAge(ageSeconds: number): string {
+  if (ageSeconds < 60) return `${ageSeconds}s`;
+  const minutes = Math.floor(ageSeconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}
+
+export function deriveReadinessTile(input: ReadinessInput & { title?: string }): ReadinessTile {
+  const { status, ageSeconds } = deriveReadiness(input);
+
+  // Keep default tile readable fast: 1 short line + optional age.
+  const subtitle =
+    status === "fresh"
+      ? `Fresh${typeof ageSeconds === "number" ? ` · ${formatAge(ageSeconds)}` : ""}`
+      : status === "stale"
+        ? `Stale${typeof ageSeconds === "number" ? ` · ${formatAge(ageSeconds)}` : ""}`
+        : status === "failed"
+          ? "Failed"
+          : "Unknown";
+
+  return {
+    kind: "readiness",
+    title: input.title ?? "Readiness",
+    status,
+    subtitle,
+    ageSeconds,
+  };
+}


### PR DESCRIPTION
$Implements Meatware guardrails for readiness/tile wiring:\n\n- Domain-first props: timestamps now live under `domain`.\n- Canonical status enum: `fresh|stale|unknown|failed` (unchanged).\n- Knobs grouped under `thresholds` (renamed from `config`).\n- Adds `deriveReadinessTile()` helper that returns a compact, quickly-readable subtitle.\n\nTests: `npm test`.\n