### PR TITLE
feat: add deriveReadiness overloads (legacy call shape)

### DIFF
--- a/src/readiness.ts
+++ b/src/readiness.ts
@@ -56,6 +56,9 @@ function normalizeReadinessInput(input: ReadinessInput | ReadinessInputLegacy): 
   };
 }
 
+// Overloads for backwards-compatible call sites.
+export function deriveReadiness(input: ReadinessInput): ReadinessDerived;
+export function deriveReadiness(input: ReadinessInputLegacy): ReadinessDerived;
 export function deriveReadiness(input: ReadinessInput | ReadinessInputLegacy): ReadinessDerived {
   const normalized = normalizeReadinessInput(input);
 


### PR DESCRIPTION
Adds TS overload signatures for deriveReadiness() so both the new domain-first ReadinessInput and the previous top-level+config legacy call shape typecheck cleanly. No runtime behavior changes; tests remain green.